### PR TITLE
Update Megacli.pm

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Linux/Storages/Megacli.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Linux/Storages/Megacli.pm
@@ -49,9 +49,16 @@ sub doInventory {
 
             # Lookup the disk info in 'ShowSummary'
             while (my ($sum_id, $sum) = each %{$summary{$adp_id}}) {
+                
+                # remove unexpected leading space
+                $pd->{'Slot Number'} =~ s/\s//g;
+
+                # assume "N/A" means '0'
+                $pd->{'Enclosure position'} =~ s/N\/A/0/;
+
                 next unless
                     $adp->{$sum->{encl_id}} == $pd->{'Enclosure Device ID'} &&
-                    $sum->{encl_pos}        == $pd->{'Enclosure position'} &&
+                    $sum->{encl_pos}        eq $pd->{'Enclosure position'} &&
                     $sum->{slot}            == $pd->{'Slot Number'};
 
                 # 'HUC101212CSS'  <-- note it is incomplete
@@ -104,10 +111,9 @@ sub doInventory {
 sub _getAdpEnclosure {
     my (%params) = @_;
 
-    my $command = $params{adp} ? "megacli -EncInfo -a$params{adp}" : undef;
+    $params{command} = exists $params{adp} ? "megacli -EncInfo -a$params{adp}" : undef;
 
     my $handle = getFileHandle(
-        command => $command,
         %params
     );
     return unless $handle;
@@ -133,10 +139,9 @@ sub _getAdpEnclosure {
 sub _getSummary {
     my (%params) = @_;
 
-    my $command = $params{adp} ? "megacli -ShowSummary -a$params{adp}" : undef;
+    $params{command} = exists $params{adp} ? "megacli -ShowSummary -a$params{adp}" : undef;
 
     my $handle = getFileHandle(
-        command => $command,
         %params
     );
     return unless $handle;
@@ -179,10 +184,9 @@ sub _getSummary {
 sub _getPDlist {
     my (%params) = @_;
 
-    my $command = $params{adp} ? "megacli -PDlist -a$params{adp}" : undef;
+    $params{command} = exists $params{adp} ? "megacli -PDlist -a$params{adp}" : undef;
 
     my $handle = getFileHandle(
-        command => $command,
         %params
     );
     return unless $handle;


### PR DESCRIPTION
- fix for numeric comparison in doInventory device matching
- fix for subroutine calls in _getAdpEnclosure _getSummary _getPDlist
- added "exists" in command test since $params{adp} might contain numeric 0 in _getAdpEnclosure _getSummary _getPDlist
- remove leading space in doInventory  ($pd->{'Slot Number'})
- substitute "N/A" with "0" in doInventory ($pd->{'Enclosure position'})